### PR TITLE
fix(past): return empty show if archiv doesn't have any info

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -42,6 +42,15 @@ def fixture_archiv_mock(requests_mock):
     )
 
 
+@fixture(name="empty_archiv_mock")
+def fixture_empty_archiv_mock(requests_mock):
+    """Mock empty record from Archiv."""
+    return requests_mock.get(
+        "https://archiv.rabe.ch/api/broadcasts/1993/03/01/131200",
+        json={"data": []},
+    )
+
+
 @fixture(name="libretime_mock")
 def fixture_libretime_mock(requests_mock):
     return requests_mock.get(

--- a/cridlib/strategy/past.py
+++ b/cridlib/strategy/past.py
@@ -21,6 +21,6 @@ def get_show(past: datetime) -> str:
     _resp = get_session().get(_url, timeout=10)
     _json = _resp.json()
     _data = _json.get("data")
-    _label = str(_data[0].get("attributes").get("label"))
+    _label = str(_data[0].get("attributes").get("label")) if len(_data) == 1 else ""
 
     return _label.lower().replace(" ", "-")

--- a/tests/strategy/test_past.py
+++ b/tests/strategy/test_past.py
@@ -14,3 +14,11 @@ def test_get_show(archiv_mock):  # pylint: disable=unused-argument
     with freeze_time("1993-03-01 13:12:00 UTC"):
         show = cridlib.strategy.past.get_show(datetime.now())
     assert show == "test"
+
+
+def test_get_show_empty(empty_archiv_mock):  # pylint: disable=unused-argument
+    """Test get_data."""
+
+    with freeze_time("1993-03-01 13:12:00 UTC"):
+        show = cridlib.strategy.past.get_show(datetime.now())
+    assert show == ""


### PR DESCRIPTION
This can happen if the Archive's data source isn't up2date, or in this case as the result of a maintenance window